### PR TITLE
Remove vega testnet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3
+
+- The Vega testnet has gone offline.
+- Removed vega testnet from `config.toml`.
+- If a user mentions vega in a message starting with '$', reply with a notification.
+
 ## v0.2
 
 - The time restriction applies separately for vega, theta, and devnet requests.

--- a/config.toml
+++ b/config.toml
@@ -8,15 +8,6 @@ denomination   = "uatom"
 decimal        = "1e6"
 
 [testnets]
-    [testnets.vega]
-    node_url = "http://165.22.235.50:26657"
-    chain_id = "vega-testnet"
-    faucet_address = "cosmos15aptdqmm7ddgtcrjvc5hs988rlrkze40l4q0he"
-    block_explorer_tx = "https://vega-explorer.hypha.coop/transactions/"
-    daily_cap = "400000000"
-    amount_to_send = "10000000"
-    tx_fees = "500"
-
     [testnets.theta]
     node_url = "http://state-sync-01.theta-testnet.polypore.xyz:26657"
     chain_id = "theta-testnet-001"

--- a/cosmos_discord_faucet.py
+++ b/cosmos_discord_faucet.py
@@ -323,6 +323,11 @@ async def on_message(message):
         await message.reply(help_msg)
         return
 
+    # Notify users of vega shutdown
+    if message.content[0] == ('$') and 'vega' in message.content.lower():
+        await message.reply(f'The Vega testnet is no longer active as of April 14, 2022. Please use Theta instead.')
+        return
+
     # Respond to commands
     for name in list(testnets.keys()):
         if name in message.content:


### PR DESCRIPTION
- Removed vega testnet from `config.toml`.
- Reply with a notification when somebody mentions 'vega' in a message starting with `$`.