### PR TITLE
Fix IBC denoms

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ denomination   = "uatom"
 
 [testnets]
     [testnets.theta]
-    node_url = "http://state-sync-01.theta-testnet.polypore.xyz:26657"
+    node_url = "http://sentry-01.theta-testnet.polypore.xyz:26657"
     chain_id = "theta-testnet-001"
     faucet_address = "cosmos15aptdqmm7ddgtcrjvc5hs988rlrkze40l4q0he"
     block_explorer_tx = "https://explorer.theta-testnet.polypore.xyz/transactions/"

--- a/cosmos_discord_faucet.py
+++ b/cosmos_discord_faucet.py
@@ -161,8 +161,9 @@ async def transaction_info(message, testnet: dict):
                 chain_id=testnet['chain_id'])
             reply = f'```' \
                 f'From:    {res["sender"]}\n' \
-                f'To:      {res["recipient"]}\n' \
-                f'Amount:  {res["amount"]}\n```'
+                f'To:      {res["receiver"]}\n' \
+                f'Amount:  {res["amount"]}\n' \
+                f'Height:  {res["height"]}\n```'
 
         except Exception:
             reply = '❗ gaia could not handle your request'

--- a/cosmos_faucet_analytics.py
+++ b/cosmos_faucet_analytics.py
@@ -3,7 +3,7 @@
 Parses transactions and writes to a
 Node Exporter file periodically.
 Usage:
-python cosmos_faucet_analytics.py [transaction log file] [node exporter textfile] [period in seconds]
+python cosmos_faucet_analytics.py [tx log file] [node exporter textfile] [period in seconds]
 Example:
 python cosmos_faucet_analytics.py transactions.csv /opt/node_exporter/textfiles/faucet_stats.prom 60
 Outputs per chain:

--- a/cosmos_transaction_reader.py
+++ b/cosmos_transaction_reader.py
@@ -140,6 +140,6 @@ class TransactionReader():
         Parses the CSV file populating self._txs and self._stats
         """
         self._txs = []
-        with open(self._filename, 'r', newline='') as csvfile:
+        with open(self._filename, 'r', newline='', encoding='utf-8') as csvfile:
             data = list(csv.reader(csvfile, delimiter=','))
         self._data = np.array(data)


### PR DESCRIPTION
Gaia calls are now made using the `--output=json` flag. The output is parsed using keys instead of regex operations. 

Full IBC denoms show up in the response to `$balance` messages now.