### PR TITLE
Remove devnet option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ prefix         = "cosmos"
 denomination   = "uatom"
 
 [testnets]
-    [testnets.public]
+    [testnets.theta]
     node_url = "http://sentry-01.theta-testnet.polypore.xyz:26657"
     chain_id = "theta-testnet-001"
     faucet_address = "cosmos15aptdqmm7ddgtcrjvc5hs988rlrkze40l4q0he"

--- a/config.toml
+++ b/config.toml
@@ -7,22 +7,13 @@ prefix         = "cosmos"
 denomination   = "uatom"
 
 [testnets]
-    [testnets.theta]
+    [testnets.public]
     node_url = "http://sentry-01.theta-testnet.polypore.xyz:26657"
     chain_id = "theta-testnet-001"
     faucet_address = "cosmos15aptdqmm7ddgtcrjvc5hs988rlrkze40l4q0he"
     block_explorer_tx = "https://explorer.theta-testnet.polypore.xyz/transactions/"
     daily_cap = "400000000"
     amount_to_send = "10000000"
-    tx_fees = "500"
-
-    [testnets.devnet]
-    node_url = "http://one.theta-devnet.polypore.xyz:26657"
-    chain_id = "theta-devnet"
-    faucet_address = "cosmos15aptdqmm7ddgtcrjvc5hs988rlrkze40l4q0he"
-    block_explorer_tx = ""
-    daily_cap = "50000000"
-    amount_to_send = "1000000"
     tx_fees = "500"
 
 [discord]

--- a/cosmos_discord_faucet.py
+++ b/cosmos_discord_faucet.py
@@ -249,7 +249,7 @@ async def token_request(message, testnet: dict):
     """
     # Extract address
     message_sections = str(message.content).lower().split()
-    if len(message_sections) != 2:
+    if len(message_sections) < 2:
         await message.reply(HELP_MSG)
     address = message_sections[1]
 
@@ -333,7 +333,7 @@ async def on_message(message):
         await message.reply(HELP_MSG)
         return
 
-    testnet = testnets['public']
+    testnet = testnets['theta']
     # Dispatch message to appropriate handler
     if message.content.startswith('$faucet_address'):
         await message.reply(f'The {testnet["name"]} faucet has address'


### PR DESCRIPTION
Discord bot will service the public testnet only. Users only need to specify a cosmos address when requesting tokens.
- Closes #23 
- Closes #24 